### PR TITLE
Change Asset loading code to work with live-reloaded data.

### DIFF
--- a/DataUtils.hx
+++ b/DataUtils.hx
@@ -1,14 +1,16 @@
 import com.stencyl.graphics.G;
 import com.stencyl.Engine;
 import com.stencyl.models.Sound;
-import nme.display.BitmapData;
+import com.stencyl.utils.Assets;
+
+import openfl.display.BitmapData;
 
 class DataUtils {
 
 	public static function getTextData(file:String):String {
 		file = "assets/data/" + file;
 		#if (flash || js)
-		var text:String = nme.Assets.getText(file);
+		var text:String = Assets.getText(file);
 		#else
 		var text:String = FileSave.getText(file);
 		#end
@@ -22,7 +24,7 @@ class DataUtils {
 	public static function getImageData(file:String):BitmapData {
 		file = "assets/data/" + file;
 		#if (flash || js)
-		var image:BitmapData = nme.Assets.getBitmapData(file);
+		var image:BitmapData = Assets.getBitmapData(file);
 		#else
 		var image:BitmapData = FileSave.getImage(file);
 		#end
@@ -87,11 +89,11 @@ class DataUtils {
 		ext = ".mp3";
 		#end
 		var file:String = "assets/data/" + filename + ext;
-		var nmeSound:flash.media.Sound = nme.Assets.getSound(file);
-		return soundToStencyl(nmeSound, filename, ext);
+		var openflSound:openfl.media.Sound = Assets.getSound(file);
+		return soundToStencyl(openflSound, filename, ext);
 	} 
 
-	public static function soundToStencyl(sound:flash.media.Sound, filename:String, ext:String):com.stencyl.models.Sound {
+	public static function soundToStencyl(sound:openfl.media.Sound, filename:String, ext:String):com.stencyl.models.Sound {
 		var stencylSound = new com.stencyl.models.Sound(-1, filename, true, false, 0.0, 1.0, ext #if (stencyl >= "4.0.0"), -1 #end);
 		stencylSound.streaming = false;
 		stencylSound.src = sound;

--- a/FileSave.hx
+++ b/FileSave.hx
@@ -3,12 +3,13 @@ import com.stencyl.behavior.Script;
 import com.stencyl.behavior.TimedTask;
 import com.stencyl.models.Font;
 import com.stencyl.graphics.G;
+import com.stencyl.utils.Assets;
 import com.stencyl.utils.Utils;
 
-import nme.display.BitmapData;
-import nme.utils.ByteArray;
 import haxe.io.Bytes;
-import openfl.Assets;
+
+import openfl.display.BitmapData;
+import openfl.utils.ByteArray;
 
 #if (openfl >= "4.0.0")
 import openfl.geom.Rectangle;
@@ -22,7 +23,7 @@ import sys.io.*;
 #if (openfl >= "4.0.0")
 import lime.system.System.*;
 #else
-import nme.utils.SystemPath.*;
+import openfl.utils.SystemPath.*;
 #end
 
 #end
@@ -46,7 +47,7 @@ class FileSave {
 		if (FileSystem.exists(path2)) {
 			content = File.getContent(path2);
 		} else {
-			content = nme.Assets.getText(path);
+			content = Assets.getText(path);
 			if (content == null) {
 				trace("ERROR: File does not exist at: " + path);
 				content = "";
@@ -86,7 +87,7 @@ class FileSave {
 			image = BitmapData.loadFromHaxeBytes(File.getBytes(path2));
 			#end
 		} else {
-			image = nme.Assets.getBitmapData(path);
+			image = Assets.getBitmapData(path);
 		}
 		if (image == null) {
 			trace("ERROR: File does not exist at: " + path);

--- a/PlaySWF.hx
+++ b/PlaySWF.hx
@@ -1,10 +1,16 @@
 import haxe.Timer;
+
 import com.stencyl.Engine;
+import com.stencyl.utils.Assets;
+
 import openfl.display.Loader;
 import openfl.display.MovieClip;
 import openfl.events.Event;
 import openfl.utils.ByteArray;
+
+#if flash
 import flash.display.AVM1Movie;
+#end
 
 class PlaySWF {
 	
@@ -33,7 +39,7 @@ class PlaySWF {
 		filepath = "assets/data/" + filename;
 		
 		try {
-			bytes = openfl.Assets.getBytes(filepath);
+			bytes = Assets.getBytes(filepath);
 		} catch (e:Dynamic) {
 			trace("Could not find " + filename);
 			whenLoaded(false);


### PR DESCRIPTION
Since Stencyl 4, Stencyl has its own Assets class that redirects to openfl/lime as needed, but can also supply reloaded asset data if the "Auto-update Running Games" option is enabled.